### PR TITLE
Added setQuoteStategy method to EntityManagerFactory

### DIFF
--- a/src/Configuration/MetaData/Fluent.php
+++ b/src/Configuration/MetaData/Fluent.php
@@ -54,6 +54,15 @@ class Fluent extends MetaData
     }
 
     /**
+     * @param  array $settings
+     * @return mixed
+     */
+    protected function getQuoteStrategy(array $settings = [])
+    {
+        return $this->container->make(Arr::get($settings, 'quote_strategy', null));
+    }
+
+    /**
      * @return string
      */
     public function getClassMetadataFactoryName()

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -120,6 +120,7 @@ class EntityManagerFactory
         }
 
         $this->setNamingStrategy($settings, $configuration);
+        $this->setQuoteStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
         $this->setCustomHydrationModes($configuration);
         $this->setCacheSettings($configuration);
@@ -314,6 +315,21 @@ class EntityManagerFactory
         $strategy = Arr::get($settings, 'naming_strategy', LaravelNamingStrategy::class);
 
         $configuration->setNamingStrategy(
+            $this->container->make($strategy)
+        );
+    }
+
+    /**
+     * @param array         $settings
+     * @param Configuration $configuration
+     */
+    protected function setQuoteStrategy(array $settings, Configuration $configuration)
+    {
+        $strategy = Arr::get($settings, 'quote_strategy', null);
+        if ($strategy === null) {
+            return;
+        }
+        $configuration->setQuoteStrategy(
             $this->container->make($strategy)
         );
     }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -444,6 +444,29 @@ class EntityManagerFactoryTest extends TestCase
         $this->assertEntityManager($manager);
     }
 
+    public function test_can_set_custom_quote_strategy()
+    {
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+        $this->settings['quote_strategy'] = 'Doctrine\ORM\Mapping\AnsiQuoteStrategy';
+
+        $strategy = m::mock('Doctrine\ORM\Mapping\AnsiQuoteStrategy');
+
+        $this->container->shouldReceive('make')
+            ->with('Doctrine\ORM\Mapping\AnsiQuoteStrategy')
+            ->once()->andReturn($strategy);
+
+        $this->configuration->shouldReceive('setQuoteStrategy')->once()->with($strategy);
+
+        $manager = $this->factory->create($this->settings);
+
+        $this->assertEntityManager($manager);
+    }
+
     public function test_can_decorate_the_entity_manager()
     {
         $this->disableDebugbar();


### PR DESCRIPTION
added method to EntityManagerFactory to allow to set the used
quote strategy (defaults to DefaultQuoteStrategy).
set by configuration key "quote_strategy".

Signed-off-by: smarcet <smarcet@gmail.com>

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
-
-
-